### PR TITLE
link DOIs to preferred resolver

### DIFF
--- a/bibpy/doi/__init__.py
+++ b/bibpy/doi/__init__.py
@@ -10,7 +10,7 @@ except ImportError:
     from urllib2 import Request, urlopen
 
 
-def retrieve(doi, source='http://dx.doi.org/{0}', raw=False, **options):
+def retrieve(doi, source='https://doi.org/{0}', raw=False, **options):
     """Download a bibtex file specified by a digital object identifier.
 
     The source is a URL containing a single format specifier which is where the


### PR DESCRIPTION
Hello!

The DOI foundation recommends a [new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that in what I understand to to be either static links, or code that generates new DOI links. Code to detect or test the old URLs should not be affected.

Cheers :-)